### PR TITLE
Two level gff proteins

### DIFF
--- a/jbrowse/data/SARS-CoV-2/NC_045512.2.gff3
+++ b/jbrowse/data/SARS-CoV-2/NC_045512.2.gff3
@@ -2,13 +2,25 @@
 ##species https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=2697049
 # Note from Scott Cain, 2020-05-20:
 #   Added Name attributes to mature_protein_region features to give the protein ID
+# Note from Scott Cain, 2020-07-20
+#   Removed redundant mature_protein_region features, adding their IDs as alias
+#      to the identical feature that remains
+# Note from Scott Cain, 2020-07023
+#   Adding parent polypeptide_region feature for all proteins. The reason is 
+#      two-fold:
+#          1. It allows the protein that is produced by ribosome slippage to
+#          be displayed linked together, and
+#          2. It allows the features to be displayed in https://github.com/GMOD/GenomeFeatureComponent
+#          which expects two-level features.
 NC_045512.2	RefSeq	region	1	29903	.	+	.	ID=NC_045512.2:1..29903;Dbxref=taxon:2697049;collection-date=Dec-2019;country=China;gb-acronym=SARS-CoV2;gbkey=Src;genome=genomic;isolate=Wuhan-Hu-1;mol_type=genomic RNA;nat-host=Homo sapiens;old-name=Wuhan seafood market pneumonia virus
 NC_045512.2	RefSeq	five_prime_UTR	1	265	.	+	.	ID=id-NC_045512.2:1..265;gbkey=5'UTR
 NC_045512.2	RefSeq	gene	266	21555	.	+	.	ID=gene-GU280_gp01;Dbxref=GeneID:43740578;Name=ORF1ab;gbkey=Gene;gene=ORF1ab;gene_biotype=protein_coding;locus_tag=GU280_gp01
 NC_045512.2	RefSeq	CDS	266	13468	.	+	0	ID=cds-YP_009724389.1;Parent=gene-GU280_gp01;Dbxref=Genbank:YP_009724389.1,GeneID:43740578;Name=YP_009724389.1;Note=pp1ab%3B translated by -1 ribosomal frameshift;exception=ribosomal slippage;gbkey=CDS;gene=ORF1ab;locus_tag=GU280_gp01;product=ORF1ab polyprotein;protein_id=YP_009724389.1
 NC_045512.2	RefSeq	CDS	13468	21555	.	+	0	ID=cds-YP_009724389.1;Parent=gene-GU280_gp01;Dbxref=Genbank:YP_009724389.1,GeneID:43740578;Name=YP_009724389.1;Note=pp1ab%3B translated by -1 ribosomal frameshift;exception=ribosomal slippage;gbkey=CDS;gene=ORF1ab;locus_tag=GU280_gp01;product=ORF1ab polyprotein;protein_id=YP_009724389.1
-NC_045512.2	RefSeq	mature_protein_region	266	805	.	+	.	Name=YP_009725297.1;ID=id-YP_009724389.1:1..180;Note=nsp1%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742608.1
-NC_045512.2	RefSeq	mature_protein_region	806	2719	.	+	.	Name=YP_009725298.1;ID=id-YP_009724389.1:181..818;Note=produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742609.1
+NC_045512.2	.	polypeptide_region	266	805	.	+	.	Name=YP_009725297.1;ID=protein1;Note=nsp1%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742608.1
+NC_045512.2	RefSeq	mature_protein_region	266	805	.	+	.	Name=YP_009725297.1;ID=id-YP_009724389.1:1..180;Note=nsp1%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742608.1;Parent=protein1
+NC_045512.2	.	polypeptide_region	806	2719	.	+	.	Name=YP_009725298.1;ID=parent2;Note=produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742609.1
+NC_045512.2	RefSeq	mature_protein_region	806	2719	.	+	.	Name=YP_009725298.1;ID=id-YP_009724389.1:181..818;Note=produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742609.1;Parent=protein2
 NC_045512.2	RefSeq	mature_protein_region	2720	8554	.	+	.	Name=YP_009725299.1;ID=id-YP_009724389.1:819..2763;Note=former nsp1%3B conserved domains are: N-terminal acidic (Ac)%2C predicted phosphoesterase%2C papain-like proteinase%2C Y-domain%2C transmembrane domain 1 (TM1)%2C adenosine diphosphate-ribose 1''-phosphatase (ADRP)%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742610.1
 NC_045512.2	RefSeq	mature_protein_region	8555	10054	.	+	.	Name=YP_009725300.1;ID=id-YP_009724389.1:2764..3263;Note=nsp4B_TM%3B contains transmembrane domain 2 (TM2)%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742611.1
 NC_045512.2	RefSeq	mature_protein_region	10055	10972	.	+	.	Name=YP_009725301.1;ID=id-YP_009724389.1:3264..3569;Note=nsp5A_3CLpro and nsp5B_3CLpro%3B main proteinase (Mpro)%3B mediates cleavages downstream of nsp4. 3D structure of the SARSr-CoV homolog has been determined (Yang et al.%2C 2003)%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742612.1

--- a/jbrowse/data/SARS-CoV-2/NC_045512.2.gff3
+++ b/jbrowse/data/SARS-CoV-2/NC_045512.2.gff3
@@ -25,7 +25,7 @@ NC_045512.2	.	polypeptide_region	806	2719	.	+	.	Name=YP_009725298.1;ID=protein2;
 NC_045512.2	RefSeq	mature_protein_region	806	2719	.	+	.	Name=YP_009725298.1;ID=id-YP_009724389.1:181..818;Note=produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742609.1;Parent=protein2
 
 NC_045512.2	.	polypeptide_region	2720	8554	.	+	.	Name=YP_009725299.1;ID=protein3;Note=former nsp1%3B conserved domains are: N-terminal acidic (Ac)%2C predicted phosphoesterase%2C papain-like proteinase%2C Y-domain%2C transmembrane domain 1 (TM1)%2C adenosine diphosphate-ribose 1''-phosphatase (ADRP)%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742610.1
-NC_045512.2	RefSeq	mature_protein_region	2720	8554	.	+	.	Name=YP_009725299.1;ID=id-YP_009724389.1:819..2763;Note=former nsp1%3B conserved domains are: N-terminal acidic (Ac)%2C predicted phosphoesterase%2C papain-like proteinase%2C Y-domain%2C transmembrane domain 1 (TM1)%2C adenosine diphosphate-ribose 1''-phosphatase (ADRP)%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742610.1;ID=protein3
+NC_045512.2	RefSeq	mature_protein_region	2720	8554	.	+	.	Name=YP_009725299.1;ID=id-YP_009724389.1:819..2763;Note=former nsp1%3B conserved domains are: N-terminal acidic (Ac)%2C predicted phosphoesterase%2C papain-like proteinase%2C Y-domain%2C transmembrane domain 1 (TM1)%2C adenosine diphosphate-ribose 1''-phosphatase (ADRP)%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742610.1;Parent=protein3
 
 NC_045512.2	.	polypeptide_region	8555	10054	.	+	.	Name=YP_009725300.1;ID=protein4;Note=nsp4B_TM%3B contains transmembrane domain 2 (TM2)%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742611.1
 NC_045512.2	RefSeq	mature_protein_region	8555	10054	.	+	.	Name=YP_009725300.1;ID=id-YP_009724389.1:2764..3263;Note=nsp4B_TM%3B contains transmembrane domain 2 (TM2)%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742611.1;Parent=protein4
@@ -128,7 +128,7 @@ NC_045512.2	.	polypeptide_region	28284	28574	.	+	.	ID=protein26;Name=P0DTD2;Note
 NC_045512.2	UniProtKB	mature_protein_region	28284	28574	.	+	.	ID=P0DTD2;Name=P0DTD2;Note=The gene encoding this protein is included within the N gene (alternative ORF). Belongs to the coronavirus group 2 protein 9b family.;Parent=protein26
 
 NC_045512.2	.	polypeptide_region	28734	28952	.	+	.	ID=protein27;Name=P0DTD3;Note=Single-pass membrane protein 
-NC_045512.2	UniProtKB	mature_protein_region	28734	28952	.	+	.	ID=P0DTD3;Name=P0DTD3;Note=Single-pass membrane protein;Parent=protein27 
+NC_045512.2	UniProtKB	mature_protein_region	28734	28952	.	+	.	ID=P0DTD3;Name=P0DTD3;Note=Single-pass membrane protein;Parent=protein27
 
 NC_045512.2	RefSeq	gene	29558	29674	.	+	.	ID=gene-GU280_gp11;Dbxref=GeneID:43740576;Name=ORF10;gbkey=Gene;gene=ORF10;gene_biotype=protein_coding;locus_tag=GU280_gp11
 NC_045512.2	RefSeq	CDS	29558	29674	.	+	0	ID=cds-YP_009725255.1;Parent=gene-GU280_gp11;Dbxref=Genbank:YP_009725255.1,GeneID:43740576;Name=YP_009725255.1;gbkey=CDS;gene=ORF10;locus_tag=GU280_gp11;product=ORF10 protein;protein_id=YP_009725255.1

--- a/jbrowse/data/SARS-CoV-2/NC_045512.2.gff3
+++ b/jbrowse/data/SARS-CoV-2/NC_045512.2.gff3
@@ -17,60 +17,125 @@ NC_045512.2	RefSeq	five_prime_UTR	1	265	.	+	.	ID=id-NC_045512.2:1..265;gbkey=5'U
 NC_045512.2	RefSeq	gene	266	21555	.	+	.	ID=gene-GU280_gp01;Dbxref=GeneID:43740578;Name=ORF1ab;gbkey=Gene;gene=ORF1ab;gene_biotype=protein_coding;locus_tag=GU280_gp01
 NC_045512.2	RefSeq	CDS	266	13468	.	+	0	ID=cds-YP_009724389.1;Parent=gene-GU280_gp01;Dbxref=Genbank:YP_009724389.1,GeneID:43740578;Name=YP_009724389.1;Note=pp1ab%3B translated by -1 ribosomal frameshift;exception=ribosomal slippage;gbkey=CDS;gene=ORF1ab;locus_tag=GU280_gp01;product=ORF1ab polyprotein;protein_id=YP_009724389.1
 NC_045512.2	RefSeq	CDS	13468	21555	.	+	0	ID=cds-YP_009724389.1;Parent=gene-GU280_gp01;Dbxref=Genbank:YP_009724389.1,GeneID:43740578;Name=YP_009724389.1;Note=pp1ab%3B translated by -1 ribosomal frameshift;exception=ribosomal slippage;gbkey=CDS;gene=ORF1ab;locus_tag=GU280_gp01;product=ORF1ab polyprotein;protein_id=YP_009724389.1
+
 NC_045512.2	.	polypeptide_region	266	805	.	+	.	Name=YP_009725297.1;ID=protein1;Note=nsp1%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742608.1
 NC_045512.2	RefSeq	mature_protein_region	266	805	.	+	.	Name=YP_009725297.1;ID=id-YP_009724389.1:1..180;Note=nsp1%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742608.1;Parent=protein1
-NC_045512.2	.	polypeptide_region	806	2719	.	+	.	Name=YP_009725298.1;ID=parent2;Note=produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742609.1
+
+NC_045512.2	.	polypeptide_region	806	2719	.	+	.	Name=YP_009725298.1;ID=protein2;Note=produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742609.1
 NC_045512.2	RefSeq	mature_protein_region	806	2719	.	+	.	Name=YP_009725298.1;ID=id-YP_009724389.1:181..818;Note=produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742609.1;Parent=protein2
-NC_045512.2	RefSeq	mature_protein_region	2720	8554	.	+	.	Name=YP_009725299.1;ID=id-YP_009724389.1:819..2763;Note=former nsp1%3B conserved domains are: N-terminal acidic (Ac)%2C predicted phosphoesterase%2C papain-like proteinase%2C Y-domain%2C transmembrane domain 1 (TM1)%2C adenosine diphosphate-ribose 1''-phosphatase (ADRP)%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742610.1
-NC_045512.2	RefSeq	mature_protein_region	8555	10054	.	+	.	Name=YP_009725300.1;ID=id-YP_009724389.1:2764..3263;Note=nsp4B_TM%3B contains transmembrane domain 2 (TM2)%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742611.1
-NC_045512.2	RefSeq	mature_protein_region	10055	10972	.	+	.	Name=YP_009725301.1;ID=id-YP_009724389.1:3264..3569;Note=nsp5A_3CLpro and nsp5B_3CLpro%3B main proteinase (Mpro)%3B mediates cleavages downstream of nsp4. 3D structure of the SARSr-CoV homolog has been determined (Yang et al.%2C 2003)%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742612.1
-NC_045512.2	RefSeq	mature_protein_region	10973	11842	.	+	.	Name=YP_009725302.1;ID=id-YP_009724389.1:3570..3859;Note=nsp6_TM%3B putative transmembrane domain%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742613.1
-NC_045512.2	RefSeq	mature_protein_region	11843	12091	.	+	.	Name=YP_009725303.1;ID=id-YP_009724389.1:3860..3942;Note=produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742614.1
-NC_045512.2	RefSeq	mature_protein_region	12092	12685	.	+	.	Name=YP_009725304.1;ID=id-YP_009724389.1:3943..4140;Note=produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742615.1
-NC_045512.2	RefSeq	mature_protein_region	12686	13024	.	+	.	Name=YP_009725305.1;ID=id-YP_009724389.1:4141..4253;Note=ssRNA-binding protein%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742616.1
-NC_045512.2	RefSeq	mature_protein_region	13025	13441	.	+	.	Name=YP_009725306.1;ID=id-YP_009724389.1:4254..4392;Note=nsp10_CysHis%3B formerly known as growth-factor-like protein (GFL)%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742617.1
-NC_045512.2	RefSeq	mature_protein_region	13442	13468	.	+	.	Name=YP_009725307.1;ID=id-YP_009724389.1:4393..5324;Note=nsp12%3B NiRAN and RdRp%3B produced by pp1ab only;gbkey=Prot
-NC_045512.2	RefSeq	mature_protein_region	13442	13480	.	+	.	Name=YP_009725312.1;ID=id-YP_009725295.1:4393..4405;Note=produced by pp1a only;gbkey=Prot
-NC_045512.2	RefSeq	mature_protein_region	13468	16236	.	+	.	Name=YP_009725307.1;ID=id-YP_009724389.1:4393..5324;Note=nsp12%3B NiRAN and RdRp%3B produced by pp1ab only;gbkey=Prot
-NC_045512.2	RefSeq	mature_protein_region	16237	18039	.	+	.	Name=YP_009725308.1;ID=id-YP_009724389.1:5325..5925;Note=nsp13_ZBD%2C nsp13_TB%2C and nsp_HEL1core%3B zinc-binding domain (ZD)%2C NTPase/helicase domain (HEL)%2C RNA 5'-triphosphatase%3B produced by pp1ab only;gbkey=Prot
-NC_045512.2	RefSeq	mature_protein_region	18040	19620	.	+	.	Name=YP_009725309.1;ID=id-YP_009724389.1:5926..6452;Note=nsp14A2_ExoN and nsp14B_NMT%3B produced by pp1ab only;gbkey=Prot
-NC_045512.2	RefSeq	mature_protein_region	19621	20658	.	+	.	Name=YP_009725310.1;ID=id-YP_009724389.1:6453..6798;Note=nsp15-A1 and nsp15B-NendoU%3B produced by pp1ab only;gbkey=Prot
-NC_045512.2	RefSeq	mature_protein_region	20659	21552	.	+	.	Name=YP_009725311.1;ID=id-YP_009724389.1:6799..7096;Note=nsp16_OMT%3B 2'-o-MT%3B produced by pp1ab only;gbkey=Prot
+
+NC_045512.2	.	polypeptide_region	2720	8554	.	+	.	Name=YP_009725299.1;ID=protein3;Note=former nsp1%3B conserved domains are: N-terminal acidic (Ac)%2C predicted phosphoesterase%2C papain-like proteinase%2C Y-domain%2C transmembrane domain 1 (TM1)%2C adenosine diphosphate-ribose 1''-phosphatase (ADRP)%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742610.1
+NC_045512.2	RefSeq	mature_protein_region	2720	8554	.	+	.	Name=YP_009725299.1;ID=id-YP_009724389.1:819..2763;Note=former nsp1%3B conserved domains are: N-terminal acidic (Ac)%2C predicted phosphoesterase%2C papain-like proteinase%2C Y-domain%2C transmembrane domain 1 (TM1)%2C adenosine diphosphate-ribose 1''-phosphatase (ADRP)%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742610.1;ID=protein3
+
+NC_045512.2	.	polypeptide_region	8555	10054	.	+	.	Name=YP_009725300.1;ID=protein4;Note=nsp4B_TM%3B contains transmembrane domain 2 (TM2)%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742611.1
+NC_045512.2	RefSeq	mature_protein_region	8555	10054	.	+	.	Name=YP_009725300.1;ID=id-YP_009724389.1:2764..3263;Note=nsp4B_TM%3B contains transmembrane domain 2 (TM2)%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742611.1;Parent=protein4
+
+NC_045512.2	.	polypeptide_region	10055	10972	.	+	.	Name=YP_009725301.1;ID=protein5;Note=nsp5A_3CLpro and nsp5B_3CLpro%3B main proteinase (Mpro)%3B mediates cleavages downstream of nsp4. 3D structure of the SARSr-CoV homolog has been determined (Yang et al.%2C 2003)%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742612.1
+NC_045512.2	RefSeq	mature_protein_region	10055	10972	.	+	.	Name=YP_009725301.1;ID=id-YP_009724389.1:3264..3569;Note=nsp5A_3CLpro and nsp5B_3CLpro%3B main proteinase (Mpro)%3B mediates cleavages downstream of nsp4. 3D structure of the SARSr-CoV homolog has been determined (Yang et al.%2C 2003)%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742612.1;Parent=protein5
+
+NC_045512.2	.	polypeptide_region	10973	11842	.	+	.	Name=YP_009725302.1;ID=protein6;Note=nsp6_TM%3B putative transmembrane domain%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742613.1
+NC_045512.2	RefSeq	mature_protein_region	10973	11842	.	+	.	Name=YP_009725302.1;ID=id-YP_009724389.1:3570..3859;Note=nsp6_TM%3B putative transmembrane domain%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742613.1;Parent=protein6
+
+NC_045512.2	.	polypeptide_region	11843	12091	.	+	.	Name=YP_009725303.1;ID=protein7;Note=produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742614.1
+NC_045512.2	RefSeq	mature_protein_region	11843	12091	.	+	.	Name=YP_009725303.1;ID=id-YP_009724389.1:3860..3942;Note=produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742614.1;Parent=protein7
+
+NC_045512.2	.	polypeptide_region	12092	12685	.	+	.	Name=YP_009725304.1;ID=protein8;Note=produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742615.1
+NC_045512.2	RefSeq	mature_protein_region	12092	12685	.	+	.	Name=YP_009725304.1;ID=id-YP_009724389.1:3943..4140;Note=produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742615.1;Parent=protein8
+
+NC_045512.2	.	polypeptide_region	12686	13024	.	+	.	Name=YP_009725305.1;ID=protein9;Note=ssRNA-binding protein%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742616.1
+NC_045512.2	RefSeq	mature_protein_region	12686	13024	.	+	.	Name=YP_009725305.1;ID=id-YP_009724389.1:4141..4253;Note=ssRNA-binding protein%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742616.1;Parent=protein9
+
+NC_045512.2	.	polypeptide_region	13025	13441	.	+	.	Name=YP_009725306.1;ID=protein10;Note=nsp10_CysHis%3B formerly known as growth-factor-like protein (GFL)%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742617.1
+NC_045512.2	RefSeq	mature_protein_region	13025	13441	.	+	.	Name=YP_009725306.1;ID=id-YP_009724389.1:4254..4392;Note=nsp10_CysHis%3B formerly known as growth-factor-like protein (GFL)%3B produced by both pp1a and pp1ab;gbkey=Prot;Alias=YP_009742617.1;Parent=protein10
+
+NC_045512.2	.	polypeptide_region	13442	16236	.	+	.	Name=YP_009725307.1;ID=protein11;Note=nsp12%3B NiRAN and RdRp%3B produced by pp1ab only;gbkey=Prot
+NC_045512.2	RefSeq	mature_protein_region	13442	13468	.	+	.	Name=YP_009725307.1;ID=id-YP_009724389.1:4393..5324;Note=nsp12%3B NiRAN and RdRp%3B produced by pp1ab only;gbkey=Prot;Parent=protein11
+NC_045512.2	RefSeq	mature_protein_region	13468	16236	.	+	.	Name=YP_009725307.1;ID=id-YP_009724389.1:4393..5324;Note=nsp12%3B NiRAN and RdRp%3B produced by pp1ab only;gbkey=Prot;Parent=protein11
+
+NC_045512.2	.	polypeptide_region	13442	13480	.	+	.	Name=YP_009725312.1;ID=protein12;Note=produced by pp1a only;gbkey=Prot
+NC_045512.2	RefSeq	mature_protein_region	13442	13480	.	+	.	Name=YP_009725312.1;ID=id-YP_009725295.1:4393..4405;Note=produced by pp1a only;gbkey=Prot;Parent=protein12
+
+NC_045512.2	.	polypeptide_region	16237	18039	.	+	.	Name=YP_009725308.1;ID=protein13;Note=nsp13_ZBD%2C nsp13_TB%2C and nsp_HEL1core%3B zinc-binding domain (ZD)%2C NTPase/helicase domain (HEL)%2C RNA 5'-triphosphatase%3B produced by pp1ab only;gbkey=Prot
+NC_045512.2	RefSeq	mature_protein_region	16237	18039	.	+	.	Name=YP_009725308.1;ID=id-YP_009724389.1:5325..5925;Note=nsp13_ZBD%2C nsp13_TB%2C and nsp_HEL1core%3B zinc-binding domain (ZD)%2C NTPase/helicase domain (HEL)%2C RNA 5'-triphosphatase%3B produced by pp1ab only;gbkey=Prot;Parent=protein13
+
+NC_045512.2	.	polypeptide_region	18040	19620	.	+	.	Name=YP_009725309.1;ID=protein14;Note=nsp14A2_ExoN and nsp14B_NMT%3B produced by pp1ab only;gbkey=Prot
+NC_045512.2	RefSeq	mature_protein_region	18040	19620	.	+	.	Name=YP_009725309.1;ID=id-YP_009724389.1:5926..6452;Note=nsp14A2_ExoN and nsp14B_NMT%3B produced by pp1ab only;gbkey=Prot;Parent=protein14
+
+NC_045512.2	.	polypeptide_region	19621	20658	.	+	.	Name=YP_009725310.1;ID=protein15;Note=nsp15-A1 and nsp15B-NendoU%3B produced by pp1ab only;gbkey=Prot
+NC_045512.2	RefSeq	mature_protein_region	19621	20658	.	+	.	Name=YP_009725310.1;ID=id-YP_009724389.1:6453..6798;Note=nsp15-A1 and nsp15B-NendoU%3B produced by pp1ab only;gbkey=Prot;Parent=protein15
+
+NC_045512.2	.	polypeptide_region	20659	21552	.	+	.	Name=YP_009725311.1;ID=protein16;Note=nsp16_OMT%3B 2'-o-MT%3B produced by pp1ab only;gbkey=Prot
+NC_045512.2	RefSeq	mature_protein_region	20659	21552	.	+	.	Name=YP_009725311.1;ID=id-YP_009724389.1:6799..7096;Note=nsp16_OMT%3B 2'-o-MT%3B produced by pp1ab only;gbkey=Prot;Parent=protein16
+
 NC_045512.2	RefSeq	CDS	266	13483	.	+	0	ID=cds-YP_009725295.1;Parent=gene-GU280_gp01;Dbxref=Genbank:YP_009725295.1,GeneID:43740578;Name=YP_009725295.1;Note=pp1a;gbkey=CDS;gene=ORF1ab;locus_tag=GU280_gp01;product=ORF1a polyprotein;protein_id=YP_009725295.1
 NC_045512.2	RefSeq	stem_loop	13476	13503	.	+	.	ID=id-GU280_gp01;Dbxref=GeneID:43740578;function=Coronavirus frameshifting stimulation element stem-loop 1;gbkey=stem_loop;gene=ORF1ab;inference=COORDINATES: profile:Rfam-release-14.1:RF00507%2CInfernal:1.1.2;locus_tag=GU280_gp01
 NC_045512.2	RefSeq	stem_loop	13488	13542	.	+	.	ID=id-GU280_gp01-2;Dbxref=GeneID:43740578;function=Coronavirus frameshifting stimulation element stem-loop 2;gbkey=stem_loop;gene=ORF1ab;inference=COORDINATES: profile:profile:Rfam-release-14.1:RF00507%2CInfernal:1.1.2;locus_tag=GU280_gp01
 NC_045512.2	RefSeq	gene	21563	25384	.	+	.	ID=gene-GU280_gp02;Dbxref=GeneID:43740568;Name=S;gbkey=Gene;gene=S;gene_biotype=protein_coding;gene_synonym=spike glycoprotein;locus_tag=GU280_gp02
 NC_045512.2	RefSeq	CDS	21563	25384	.	+	0	ID=cds-YP_009724390.1;Parent=gene-GU280_gp02;Dbxref=Genbank:YP_009724390.1,GeneID:43740568;Name=YP_009724390.1;Note=structural protein%3B spike protein;gbkey=CDS;gene=S;locus_tag=GU280_gp02;product=surface glycoprotein;protein_id=YP_009724390.1
-NC_045512.2	RefSeq	mature_protein_region	21563	25384	.	+	.	ID=id-YP_009724390.1:21563..25384;gbkey=Prot;Note=surface glycoprotein;Name=YP_009724390.1
+
+NC_045512.2	.	polypeptide_region	21563	25384	.	+	.	ID=protein17;gbkey=Prot;Note=surface glycoprotein;Name=YP_009724390.1
+NC_045512.2	RefSeq	mature_protein_region	21563	25384	.	+	.	ID=id-YP_009724390.1:21563..25384;gbkey=Prot;Note=surface glycoprotein;Name=YP_009724390.1;Parent=protein17
+
 NC_045512.2	RefSeq	gene	25393	26220	.	+	.	ID=gene-GU280_gp03;Dbxref=GeneID:43740569;Name=ORF3a;gbkey=Gene;gene=ORF3a;gene_biotype=protein_coding;locus_tag=GU280_gp03
 NC_045512.2	RefSeq	CDS	25393	26220	.	+	0	ID=cds-YP_009724391.1;Parent=gene-GU280_gp03;Dbxref=Genbank:YP_009724391.1,GeneID:43740569;Name=YP_009724391.1;gbkey=CDS;gene=ORF3a;locus_tag=GU280_gp03;product=ORF3a protein;protein_id=YP_009724391.1
-NC_045512.2	RefSeq	mature_protein_region	25393	26220	.	+	.	ID=id-YP_009724391.1:25393..26220;gbkey=Prot;Note=ORF3a protein;Name=YP_009724391.1
+
+NC_045512.2	.	polypeptide_region	25393	26220	.	+	.	ID=protein18;gbkey=Prot;Note=ORF3a protein;Name=YP_009724391.1
+NC_045512.2	RefSeq	mature_protein_region	25393	26220	.	+	.	ID=id-YP_009724391.1:25393..26220;gbkey=Prot;Note=ORF3a protein;Name=YP_009724391.1;Parent=protein18
+
 NC_045512.2	RefSeq	gene	26245	26472	.	+	.	ID=gene-GU280_gp04;Dbxref=GeneID:43740570;Name=E;gbkey=Gene;gene=E;gene_biotype=protein_coding;locus_tag=GU280_gp04
 NC_045512.2	RefSeq	CDS	26245	26472	.	+	0	ID=cds-YP_009724392.1;Parent=gene-GU280_gp04;Dbxref=Genbank:YP_009724392.1,GeneID:43740570;Name=YP_009724392.1;Note=ORF4%3B structural protein%3B E protein;gbkey=CDS;gene=E;locus_tag=GU280_gp04;product=envelope protein;protein_id=YP_009724392.1
-NC_045512.2	RefSeq	mature_protein_region	26245	26472	.	+	.	ID=id-YP_009724392.1:26245..26472;gbkey=Prot;Note=envelope protein;Name=YP_009724392.1
+
+NC_045512.2	.	polypeptide_region	26245	26472	.	+	.	ID=protein19;gbkey=Prot;Note=envelope protein;Name=YP_009724392.1
+NC_045512.2	RefSeq	mature_protein_region	26245	26472	.	+	.	ID=id-YP_009724392.1:26245..26472;gbkey=Prot;Note=envelope protein;Name=YP_009724392.1;Parent=protein19
+
 NC_045512.2	RefSeq	gene	26523	27191	.	+	.	ID=gene-GU280_gp05;Dbxref=GeneID:43740571;Name=M;gbkey=Gene;gene=M;gene_biotype=protein_coding;locus_tag=GU280_gp05
 NC_045512.2	RefSeq	CDS	26523	27191	.	+	0	ID=cds-YP_009724393.1;Parent=gene-GU280_gp05;Dbxref=Genbank:YP_009724393.1,GeneID:43740571;Name=YP_009724393.1;Note=ORF5%3B structural protein;gbkey=CDS;gene=M;locus_tag=GU280_gp05;product=membrane glycoprotein;protein_id=YP_009724393.1
-NC_045512.2	RefSeq	mature_protein_region	26523	27191	.	+	.	ID=id-YP_009724393.1:26523..27191;gbkey=Prot;Note=membrane glycoprotein;Name=YP_009724393.1
+
+NC_045512.2	.	polypeptide_region	26523	27191	.	+	.	ID=protein20;gbkey=Prot;Note=membrane glycoprotein;Name=YP_009724393.1
+NC_045512.2	RefSeq	mature_protein_region	26523	27191	.	+	.	ID=id-YP_009724393.1:26523..27191;gbkey=Prot;Note=membrane glycoprotein;Name=YP_009724393.1;Parent=protein20
+
 NC_045512.2	RefSeq	gene	27202	27387	.	+	.	ID=gene-GU280_gp06;Dbxref=GeneID:43740572;Name=ORF6;gbkey=Gene;gene=ORF6;gene_biotype=protein_coding;locus_tag=GU280_gp06
 NC_045512.2	RefSeq	CDS	27202	27387	.	+	0	ID=cds-YP_009724394.1;Parent=gene-GU280_gp06;Dbxref=Genbank:YP_009724394.1,GeneID:43740572;Name=YP_009724394.1;gbkey=CDS;gene=ORF6;locus_tag=GU280_gp06;product=ORF6 protein;protein_id=YP_009724394.1
-NC_045512.2	RefSeq	mature_protein_region	27202	27387	.	+	.	ID=id-YP_009724394.1:27202..27387;gbkey=Prot;Note=ORF6 protein;Name=YP_009724394.1
+
+NC_045512.2	.	polypeptide_region	27202	27387	.	+	.	ID=protein21;gbkey=Prot;Note=ORF6 protein;Name=YP_009724394.1
+NC_045512.2	RefSeq	mature_protein_region	27202	27387	.	+	.	ID=id-YP_009724394.1:27202..27387;gbkey=Prot;Note=ORF6 protein;Name=YP_009724394.1;Parent=protein21
+
 NC_045512.2	RefSeq	gene	27394	27759	.	+	.	ID=gene-GU280_gp07;Dbxref=GeneID:43740573;Name=ORF7a;gbkey=Gene;gene=ORF7a;gene_biotype=protein_coding;locus_tag=GU280_gp07
 NC_045512.2	RefSeq	CDS	27394	27759	.	+	0	ID=cds-YP_009724395.1;Parent=gene-GU280_gp07;Dbxref=Genbank:YP_009724395.1,GeneID:43740573;Name=YP_009724395.1;gbkey=CDS;gene=ORF7a;locus_tag=GU280_gp07;product=ORF7a protein;protein_id=YP_009724395.1
-NC_045512.2	RefSeq	mature_protein_region	27394	27759	.	+	.	ID=id-YP_009724395.1:27394..27759;gbkey=Prot;Note=ORF7a protein;Name=YP_009724395.1
+
+NC_045512.2	.	polypeptide_region	27394	27759	.	+	.	ID=protein22;gbkey=Prot;Note=ORF7a protein;Name=YP_009724395.1
+NC_045512.2	RefSeq	mature_protein_region	27394	27759	.	+	.	ID=id-YP_009724395.1:27394..27759;gbkey=Prot;Note=ORF7a protein;Name=YP_009724395.1;Parent=protein22
+
 NC_045512.2	RefSeq	gene	27756	27887	.	+	.	ID=gene-GU280_gp08;Dbxref=GeneID:43740574;Name=ORF7b;gbkey=Gene;gene=ORF7b;gene_biotype=protein_coding;locus_tag=GU280_gp08
 NC_045512.2	RefSeq	CDS	27756	27887	.	+	0	ID=cds-YP_009725318.1;Parent=gene-GU280_gp08;Dbxref=Genbank:YP_009725318.1,GeneID:43740574;Name=YP_009725318.1;gbkey=CDS;gene=ORF7b;locus_tag=GU280_gp08;product=ORF7b;protein_id=YP_009725318.1
-NC_045512.2	RefSeq	mature_protein_region	27756	27887	.	+	.	ID=id-YP_009725318.1:27756..27887;gbkey=Prot;Note=ORF7b;Name=YP_009725318.1
+
+NC_045512.2	.	polypeptide_region	27756	27887	.	+	.	ID=protein23;gbkey=Prot;Note=ORF7b;Name=YP_009725318.1
+NC_045512.2	RefSeq	mature_protein_region	27756	27887	.	+	.	ID=id-YP_009725318.1:27756..27887;gbkey=Prot;Note=ORF7b;Name=YP_009725318.1;Parent=protein23
+
 NC_045512.2	RefSeq	gene	27894	28259	.	+	.	ID=gene-GU280_gp09;Dbxref=GeneID:43740577;Name=ORF8;gbkey=Gene;gene=ORF8;gene_biotype=protein_coding;locus_tag=GU280_gp09
 NC_045512.2	RefSeq	CDS	27894	28259	.	+	0	ID=cds-YP_009724396.1;Parent=gene-GU280_gp09;Dbxref=Genbank:YP_009724396.1,GeneID:43740577;Name=YP_009724396.1;gbkey=CDS;gene=ORF8;locus_tag=GU280_gp09;product=ORF8 protein;protein_id=YP_009724396.1
-NC_045512.2	RefSeq	mature_protein_region	27894	28259	.	+	.	ID=id-YP_009724396.1:27894..28259;gbkey=Prot;Note=ORF8 protein;Name=YP_009724396.1
+
+NC_045512.2	.	polypeptide_region	27894	28259	.	+	.	ID=protein24;gbkey=Prot;Note=ORF8 protein;Name=YP_009724396.1
+NC_045512.2	RefSeq	mature_protein_region	27894	28259	.	+	.	ID=id-YP_009724396.1:27894..28259;gbkey=Prot;Note=ORF8 protein;Name=YP_009724396.1;Parent=protein24
+
 NC_045512.2	RefSeq	gene	28274	29533	.	+	.	ID=gene-GU280_gp10;Dbxref=GeneID:43740575;Name=N;gbkey=Gene;gene=N;gene_biotype=protein_coding;locus_tag=GU280_gp10
 NC_045512.2	RefSeq	CDS	28274	29533	.	+	0	ID=cds-YP_009724397.2;Parent=gene-GU280_gp10;Dbxref=Genbank:YP_009724397.2,GeneID:43740575;Name=YP_009724397.2;Note=ORF9%3B structural protein;gbkey=CDS;gene=N;locus_tag=GU280_gp10;product=nucleocapsid phosphoprotein;protein_id=YP_009724397.2
-NC_045512.2	RefSeq	mature_protein_region	28274	29533	.	+	.	ID=id-YP_009724397.2;gbkey=Prot;Note=nucleocapsid phosphoprotein;Name=YP_009724397.2
-NC_045512.2	UniProtKB	mature_protein_region	28284	28574	.	+	.	ID=P0DTD2;Name=P0DTD2;Note=The gene encoding this protein is included within the N gene (alternative ORF). Belongs to the coronavirus group 2 protein 9b family.
-NC_045512.2	UniProtKB	mature_protein_region	28734	28952	.	+	.	ID=P0DTD3;Name=P0DTD3;Note=Single-pass membrane protein 
+
+NC_045512.2	.	polypeptide_region	28274	29533	.	+	.	ID=protein25;gbkey=Prot;Note=nucleocapsid phosphoprotein;Name=YP_009724397.2
+NC_045512.2	RefSeq	mature_protein_region	28274	29533	.	+	.	ID=id-YP_009724397.2;gbkey=Prot;Note=nucleocapsid phosphoprotein;Name=YP_009724397.2;Parent=protein25
+
+NC_045512.2	.	polypeptide_region	28284	28574	.	+	.	ID=protein26;Name=P0DTD2;Note=The gene encoding this protein is included within the N gene (alternative ORF). Belongs to the coronavirus group 2 protein 9b family.
+NC_045512.2	UniProtKB	mature_protein_region	28284	28574	.	+	.	ID=P0DTD2;Name=P0DTD2;Note=The gene encoding this protein is included within the N gene (alternative ORF). Belongs to the coronavirus group 2 protein 9b family.;Parent=protein26
+
+NC_045512.2	.	polypeptide_region	28734	28952	.	+	.	ID=protein27;Name=P0DTD3;Note=Single-pass membrane protein 
+NC_045512.2	UniProtKB	mature_protein_region	28734	28952	.	+	.	ID=P0DTD3;Name=P0DTD3;Note=Single-pass membrane protein;Parent=protein27 
+
 NC_045512.2	RefSeq	gene	29558	29674	.	+	.	ID=gene-GU280_gp11;Dbxref=GeneID:43740576;Name=ORF10;gbkey=Gene;gene=ORF10;gene_biotype=protein_coding;locus_tag=GU280_gp11
 NC_045512.2	RefSeq	CDS	29558	29674	.	+	0	ID=cds-YP_009725255.1;Parent=gene-GU280_gp11;Dbxref=Genbank:YP_009725255.1,GeneID:43740576;Name=YP_009725255.1;gbkey=CDS;gene=ORF10;locus_tag=GU280_gp11;product=ORF10 protein;protein_id=YP_009725255.1
-NC_045512.2	RefSeq	mature_protein_region	29558	29674	.	+	.	ID=id-YP_009725255.1:29558..29674;gbkey=Prot;Note=ORF10 protein;Name=YP_009725255.1
+
+NC_045512.2	.	polypeptide_region	29558	29674	.	+	.	ID=protein28;gbkey=Prot;Note=ORF10 protein;Name=YP_009725255.1
+NC_045512.2	RefSeq	mature_protein_region	29558	29674	.	+	.	ID=id-YP_009725255.1:29558..29674;gbkey=Prot;Note=ORF10 protein;Name=YP_009725255.1;Parent=protein28
+
 NC_045512.2	RefSeq	stem_loop	29609	29644	.	+	.	ID=id-GU280_gp11;Dbxref=GeneID:43740576;function=Coronavirus 3' UTR pseudoknot stem-loop 1;gbkey=stem_loop;gene=ORF10;inference=COORDINATES: profile::Rfam-release-14.1:RF00165%2CInfernal:1.1.2;locus_tag=GU280_gp11
 NC_045512.2	RefSeq	stem_loop	29629	29657	.	+	.	ID=id-GU280_gp11-2;Dbxref=GeneID:43740576;function=Coronavirus 3' UTR pseudoknot stem-loop 2;gbkey=stem_loop;gene=ORF10;inference=COORDINATES: profile::Rfam-release-14.1:RF00165%2CInfernal:1.1.2;locus_tag=GU280_gp11
 NC_045512.2	RefSeq	three_prime_UTR	29675	29903	.	+	.	ID=id-NC_045512.2:29675..29903;gbkey=3'UTR

--- a/jbrowse/data/SARS-CoV-2/trackList.json
+++ b/jbrowse/data/SARS-CoV-2/trackList.json
@@ -1,383 +1,385 @@
 {
    "dataset_id" : "SARS-CoV-2",
    "formatVersion" : 1,
-   "include" : ["ssr.json"],
+   "include" : [
+      "ssr.json"
+   ],
    "names" : {
       "type" : "Hash",
       "url" : "https://s3.amazonaws.com/gmod-genomes-of-interest/jbrowse/data/SARS-CoV-2/names/"
    },
    "tracks" : [
-      { 
+      {
+         "category" : "UCSC/Uniprot",
          "key" : "Signal Peptides",
-	 "label" : "Signal Peptides",
-	 "storeClass" : "JBrowse/Store/SeqFeature/BigBed",
-	 "type" : "CanvasFeatures",
-         "unsafeMouseover" : true,
-         "unsafePopup" : true,
-	 "category" : "UCSC/Uniprot",
-	 "metadata" : {
+         "label" : "Signal Peptides",
+         "metadata" : {
             "about" : "Data from UniProt and prepared for display on the UCSC Genome Browser.  For more information about how this data set was prepared, see the <a href='http://www.genome.ucsc.edu/cgi-bin/hgTrackUi?hgsid=838815831_fjZBJ1KZkzbjMAnW70r6QdelQn61&g=unipCov2LocSignal&hgTracksConfigPage=configure'>information page at UCSC</a>."
-	 },
-	 "style" : {
-            "height": 8,
+         },
+         "storeClass" : "JBrowse/Store/SeqFeature/BigBed",
+         "style" : {
+            "height" : 8,
             "showLabels" : false
          },
+         "type" : "CanvasFeatures",
+         "unsafeMouseover" : true,
+         "unsafePopup" : true,
          "urlTemplate" : "https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/uniprot/unipLocSignalCov2.bb"
       },
       {
+         "category" : "UCSC/Uniprot",
          "key" : "Regions of interest",
          "label" : "Regions of interest",
-         "storeClass" : "JBrowse/Store/SeqFeature/BigBed",
-         "type" : "CanvasFeatures",
-         "unsafeMouseover" : true,
-         "unsafePopup" : true,
-         "category" : "UCSC/Uniprot",
          "metadata" : {
             "about" : "Data from UniProt and prepared for display on the UCSC Genome Browser.  For more information about how this data set was prepared, see the <a href='http://www.genome.ucsc.edu/cgi-bin/hgTrackUi?hgsid=838815831_fjZBJ1KZkzbjMAnW70r6QdelQn61&g=unipCov2Interest&hgTracksConfigPage=configure'>information page at UCSC</a>."
          },
+         "storeClass" : "JBrowse/Store/SeqFeature/BigBed",
+         "type" : "CanvasFeatures",
+         "unsafeMouseover" : true,
+         "unsafePopup" : true,
          "urlTemplate" : "https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/uniprot/unipInterestCov2.bb"
       },
       {
+         "category" : "UCSC/Uniprot",
          "key" : "Transmembrane domains",
          "label" : "Transmembrane domains",
-         "storeClass" : "JBrowse/Store/SeqFeature/BigBed",
-         "type" : "CanvasFeatures",
-         "unsafeMouseover" : true,
-         "unsafePopup" : true,
-         "category" : "UCSC/Uniprot",
          "metadata" : {
             "about" : "Data from UniProt and prepared for display on the UCSC Genome Browser.  For more information about how this data set was prepared, see the <a href='http://www.genome.ucsc.edu/cgi-bin/hgTrackUi?hgsid=838815831_fjZBJ1KZkzbjMAnW70r6QdelQn61&g=unipCov2LocTransMemb&hgTracksConfigPage=configure'>information page at UCSC</a>."
          },
-	 "style" : {
-            "height": 8,
+         "storeClass" : "JBrowse/Store/SeqFeature/BigBed",
+         "style" : {
+            "height" : 8,
             "showLabels" : false
          },
+         "type" : "CanvasFeatures",
+         "unsafeMouseover" : true,
+         "unsafePopup" : true,
          "urlTemplate" : "https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/uniprot/unipLocTransMembCov2.bb"
       },
       {
+         "category" : "UCSC/Uniprot",
          "key" : "Disulfide bonds",
          "label" : "Disulfide bonds",
-         "storeClass" : "JBrowse/Store/SeqFeature/BigBed",
-         "type" : "CanvasFeatures",
-         "unsafeMouseover" : true,
-         "unsafePopup" : true,
-         "category" : "UCSC/Uniprot",
          "metadata" : {
             "about" : "Data from UniProt and prepared for display on the UCSC Genome Browser.  For more information about how this data set was prepared, see the <a href='http://www.genome.ucsc.edu/cgi-bin/hgTrackUi?hgsid=838815831_fjZBJ1KZkzbjMAnW70r6QdelQn61&g=unipCov2DisulfBond&hgTracksConfigPage=configure'>information page at UCSC</a>."
          },
-	 "style" : {
-            "height": 8,
+         "storeClass" : "JBrowse/Store/SeqFeature/BigBed",
+         "style" : {
+            "height" : 8,
             "showLabels" : false
          },
+         "type" : "CanvasFeatures",
+         "unsafeMouseover" : true,
+         "unsafePopup" : true,
          "urlTemplate" : "https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/uniprot/unipDisulfBondCov2.bb"
       },
       {
+         "category" : "UCSC/Uniprot",
          "key" : "Protein domains",
          "label" : "Protein domains",
-         "storeClass" : "JBrowse/Store/SeqFeature/BigBed",
-         "type" : "CanvasFeatures",
-         "unsafeMouseover" : true,
-         "unsafePopup" : true,
-         "category" : "UCSC/Uniprot",
          "metadata" : {
             "about" : "Data from UniProt and prepared for display on the UCSC Genome Browser.  For more information about how this data set was prepared, see the <a href='http://www.genome.ucsc.edu/cgi-bin/hgTrackUi?hgsid=838815831_fjZBJ1KZkzbjMAnW70r6QdelQn61&g=unipCov2Domain&hgTracksConfigPage=configure'>information page at UCSC</a>."
          },
+         "storeClass" : "JBrowse/Store/SeqFeature/BigBed",
+         "type" : "CanvasFeatures",
+         "unsafeMouseover" : true,
+         "unsafePopup" : true,
          "urlTemplate" : "https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/uniprot/unipDomainCov2.bb"
       },
       {
+         "category" : "UCSC/Uniprot",
          "key" : "Glycosylation or Phosphorylation sites",
          "label" : "Glycosylation or Phosphorylation sites",
-         "storeClass" : "JBrowse/Store/SeqFeature/BigBed",
-         "type" : "CanvasFeatures",
-         "unsafeMouseover" : true,
-         "unsafePopup" : true,
-         "category" : "UCSC/Uniprot",
          "metadata" : {
             "about" : "Data from UniProt and prepared for display on the UCSC Genome Browser.  For more information about how this data set was prepared, see the <a href='http://www.genome.ucsc.edu/cgi-bin/hgTrackUi?hgsid=838815831_fjZBJ1KZkzbjMAnW70r6QdelQn61&g=unipCov2Modif&hgTracksConfigPage=configure'>information page at UCSC</a>."
          },
+         "storeClass" : "JBrowse/Store/SeqFeature/BigBed",
+         "type" : "CanvasFeatures",
+         "unsafeMouseover" : true,
+         "unsafePopup" : true,
          "urlTemplate" : "https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/uniprot/unipModifCov2.bb"
       },
       {
+         "category" : "UCSC/Uniprot",
          "key" : "Other annotations",
          "label" : "Other annotations",
-         "storeClass" : "JBrowse/Store/SeqFeature/BigBed",
-         "type" : "CanvasFeatures",
-         "unsafeMouseover" : true,
-         "unsafePopup" : true,
-         "category" : "UCSC/Uniprot",
          "metadata" : {
             "about" : "Data from UniProt and prepared for display on the UCSC Genome Browser.  For more information about how this data set was prepared, see the <a href='http://www.genome.ucsc.edu/cgi-bin/hgTrackUi?hgsid=838815831_fjZBJ1KZkzbjMAnW70r6QdelQn61&g=unipCov2Other&hgTracksConfigPage=configure'>information page at UCSC</a>."
          },
+         "storeClass" : "JBrowse/Store/SeqFeature/BigBed",
+         "type" : "CanvasFeatures",
+         "unsafeMouseover" : true,
+         "unsafePopup" : true,
          "urlTemplate" : "https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/uniprot/unipOtherCov2.bb"
       },
       {
+         "category" : "UCSC/Uniprot",
          "key" : "Repeats",
          "label" : "Repeats",
-         "storeClass" : "JBrowse/Store/SeqFeature/BigBed",
-         "type" : "CanvasFeatures",
-         "unsafeMouseover" : true,
-         "unsafePopup" : true,
-         "category" : "UCSC/Uniprot",
          "metadata" : {
             "about" : "Data from UniProt and prepared for display on the UCSC Genome Browser.  For more information about how this data set was prepared, see the <a href='http://www.genome.ucsc.edu/cgi-bin/hgTrackUi?hgsid=838815831_fjZBJ1KZkzbjMAnW70r6QdelQn61&g=unipCov2Repeat&hgTracksConfigPage=configure'>information page at UCSC</a>."
          },
-	 "style" : {
-            "height": 8,
+         "storeClass" : "JBrowse/Store/SeqFeature/BigBed",
+         "style" : {
+            "height" : 8,
             "showLabels" : false
          },
-         "urlTemplate" : "https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/uniprot/unipRepeatCov2.bb"
-      },
-      {
-         "key" : "Protease clevage sites",
-         "label" : "Protease clevage sites",
-         "storeClass" : "JBrowse/Store/SeqFeature/BigBed",
          "type" : "CanvasFeatures",
          "unsafeMouseover" : true,
          "unsafePopup" : true,
+         "urlTemplate" : "https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/uniprot/unipRepeatCov2.bb"
+      },
+      {
          "category" : "UCSC/Uniprot",
+         "key" : "Protease clevage sites",
+         "label" : "Protease clevage sites",
          "metadata" : {
             "about" : "Data from UniProt and prepared for display on the UCSC Genome Browser.  For more information about how this data set was prepared, see the <a href='http://www.genome.ucsc.edu/cgi-bin/hgTrackUi?hgsid=838815831_fjZBJ1KZkzbjMAnW70r6QdelQn61&g=unipProtease&hgTracksConfigPage=configure'>information page at UCSC</a>."
          },
+         "storeClass" : "JBrowse/Store/SeqFeature/BigBed",
          "style" : {
-            "height": 8,
+            "height" : 8,
             "showLabels" : false
          },
+         "type" : "CanvasFeatures",
+         "unsafeMouseover" : true,
+         "unsafePopup" : true,
          "urlTemplate" : "https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/uniprot/protease_sites.bb"
       },
       {
+         "category" : "UCSC/Conservation",
          "key" : "Bat coronaviruses",
-	 "label" : "Bat coronaviruses",
-	 "storeClass" : "JBrowse/Store/SeqFeature/BigWig",
-         "type" : "JBrowse/View/Track/Wiggle/XYPlot",
-         "unsafeMouseover" : true,
-         "unsafePopup" : true,
-         "category" : "UCSC/Conservation",
-	 "metadata" : {
-         "about" : "Data for sequence conservation for 44 coronaviruses circulating in bats. Created for display in the UCSC Genome Browser.  For more information about how this data set was prepared, see the <a href='http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/phyloP44way/'>information page at UCSC</a>."
-         },
-	 "style" : {
-            "height" : 20,
-            "pos_color"  : "grey"
-         },
-	 "max_score" : 5,
-         "min_score" : 0,
-	 "urlTemplate" : "http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/phyloP44way/wuhCor1.phyloP44way.bw"
-      },
-{
-         "key" : "Vertibrate coronaviruses",
-         "label" : "Vertibrate coronaviruses",
-         "storeClass" : "JBrowse/Store/SeqFeature/BigWig",
-         "type" : "JBrowse/View/Track/Wiggle/XYPlot",
-         "unsafeMouseover" : true,
-         "unsafePopup" : true,
-         "category" : "UCSC/Conservation",
+         "label" : "Bat coronaviruses",
+         "max_score" : 5,
          "metadata" : {
-         "about" : "Data for sequence conservation for 119 coronaviruses circulating in vertibrates. Created for display in the UCSC Genome Browser.  For more information about how this data set was prepared, see the <a href='http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/phyloP119way/'>information page at UCSC</a>."
+            "about" : "Data for sequence conservation for 44 coronaviruses circulating in bats. Created for display in the UCSC Genome Browser.  For more information about how this data set was prepared, see the <a href='http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/phyloP44way/'>information page at UCSC</a>."
          },
+         "min_score" : 0,
+         "storeClass" : "JBrowse/Store/SeqFeature/BigWig",
          "style" : {
             "height" : 20,
-            "pos_color"  : "grey"
+            "pos_color" : "grey"
          },
-	 "max_score" : 20,
+         "type" : "JBrowse/View/Track/Wiggle/XYPlot",
+         "unsafeMouseover" : true,
+         "unsafePopup" : true,
+         "urlTemplate" : "http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/phyloP44way/wuhCor1.phyloP44way.bw"
+      },
+      {
+         "category" : "UCSC/Conservation",
+         "key" : "Vertibrate coronaviruses",
+         "label" : "Vertibrate coronaviruses",
+         "max_score" : 20,
+         "metadata" : {
+            "about" : "Data for sequence conservation for 119 coronaviruses circulating in vertibrates. Created for display in the UCSC Genome Browser.  For more information about how this data set was prepared, see the <a href='http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/phyloP119way/'>information page at UCSC</a>."
+         },
          "min_score" : 0,
+         "storeClass" : "JBrowse/Store/SeqFeature/BigWig",
+         "style" : {
+            "height" : 20,
+            "pos_color" : "grey"
+         },
+         "type" : "JBrowse/View/Track/Wiggle/XYPlot",
+         "unsafeMouseover" : true,
+         "unsafePopup" : true,
          "urlTemplate" : "http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/phyloP119way/wuhCor1.phyloP119way.bw"
       },
       {
+         "category" : "UCSC/NextStrain",
          "glyph" : "wormbase-glyphs/View/FeatureGlyph/Diamond",
          "key" : " All",
          "label" : " All",
          "metadata" : {
             "about" : "Data derived from NextStrain and displayed on the UCSC Genome Browser. Data for these tracks are coming directly from UCSC servers at https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/nextstrain/. For more infomation about these tracks, see the <a href='http://genome.ucsc.edu/cgi-bin/hgTrackUi?hgsid=840033753_siwhRKP6atS4zAGHBh5gXRmKiyIz&c=NC_045512v2&g=nextstrainSamples'>UCSC/NextStrain information page</a>"
          },
-	 "style" : {
-            "height": 8,
-	    "showLabels" : false
-	 },
-	 "storeClass" : "JBrowse/Store/SeqFeature/VCFTabix",
+         "storeClass" : "JBrowse/Store/SeqFeature/VCFTabix",
+         "style" : {
+            "height" : 8,
+            "showLabels" : false
+         },
          "type" : "CanvasVariants",
          "unsafeMouseover" : true,
          "unsafePopup" : true,
-	 "category" : "UCSC/NextStrain",
          "urlTemplate" : "https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/nextstrain/nextstrainSamples.vcf.gz"
       },
       {
+         "category" : "UCSC/NextStrain",
          "glyph" : "wormbase-glyphs/View/FeatureGlyph/Diamond",
          "key" : "A1a",
          "label" : "A1a",
          "metadata" : {
             "about" : "Data derived from NextStrain and displayed on the UCSC Genome Browser. Data for these tracks are coming directly from UCSC servers at https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/nextstrain/. For more infomation about these tracks, see the <a href='http://genome.ucsc.edu/cgi-bin/hgTrackUi?hgsid=840033753_siwhRKP6atS4zAGHBh5gXRmKiyIz&c=NC_045512v2&g=nextstrainSamples'>UCSC/NextStrain information page</a>"
          },
-	 "style" : {
-            "height": 8,
+         "storeClass" : "JBrowse/Store/SeqFeature/VCFTabix",
+         "style" : {
+            "height" : 8,
             "showLabels" : false
          },
-         "storeClass" : "JBrowse/Store/SeqFeature/VCFTabix",
          "type" : "CanvasVariants",
          "unsafeMouseover" : true,
          "unsafePopup" : true,
-	 "category" : "UCSC/NextStrain",
          "urlTemplate" : "https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/nextstrain/nextstrainSamplesA1a.vcf.gz"
       },
       {
+         "category" : "UCSC/NextStrain",
          "glyph" : "wormbase-glyphs/View/FeatureGlyph/Diamond",
          "key" : "A2",
          "label" : "A2",
          "metadata" : {
             "about" : "Data derived from NextStrain and displayed on the UCSC Genome Browser. Data for these tracks are coming directly from UCSC servers at https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/nextstrain/. For more infomation about these tracks, see the <a href='http://genome.ucsc.edu/cgi-bin/hgTrackUi?hgsid=840033753_siwhRKP6atS4zAGHBh5gXRmKiyIz&c=NC_045512v2&g=nextstrainSamples'>UCSC/NextStrain information page</a>"
          },
-	 "style" : {
-            "height": 8,
+         "storeClass" : "JBrowse/Store/SeqFeature/VCFTabix",
+         "style" : {
+            "height" : 8,
             "showLabels" : false
          },
-         "storeClass" : "JBrowse/Store/SeqFeature/VCFTabix",
          "type" : "CanvasVariants",
          "unsafeMouseover" : true,
          "unsafePopup" : true,
-         "category" : "UCSC/NextStrain",
          "urlTemplate" : "https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/nextstrain/nextstrainSamplesA2.vcf.gz"
       },
       {
+         "category" : "UCSC/NextStrain",
          "glyph" : "wormbase-glyphs/View/FeatureGlyph/Diamond",
          "key" : "A2a",
          "label" : "A2a",
          "metadata" : {
             "about" : "Data derived from NextStrain and displayed on the UCSC Genome Browser. Data for these tracks are coming directly from UCSC servers at https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/nextstrain/. For more infomation about these tracks, see the <a href='http://genome.ucsc.edu/cgi-bin/hgTrackUi?hgsid=840033753_siwhRKP6atS4zAGHBh5gXRmKiyIz&c=NC_045512v2&g=nextstrainSamples'>UCSC/NextStrain information page</a>"
          },
-	 "style" : {
-            "height": 8,
+         "storeClass" : "JBrowse/Store/SeqFeature/VCFTabix",
+         "style" : {
+            "height" : 8,
             "showLabels" : false
          },
-         "storeClass" : "JBrowse/Store/SeqFeature/VCFTabix",
          "type" : "CanvasVariants",
          "unsafeMouseover" : true,
          "unsafePopup" : true,
-         "category" : "UCSC/NextStrain",
          "urlTemplate" : "https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/nextstrain/nextstrainSamplesA2a.vcf.gz"
       },
-            {
+      {
+         "category" : "UCSC/NextStrain",
          "glyph" : "wormbase-glyphs/View/FeatureGlyph/Diamond",
          "key" : "A3",
          "label" : "A3",
          "metadata" : {
             "about" : "Data derived from NextStrain and displayed on the UCSC Genome Browser. Data for these tracks are coming directly from UCSC servers at https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/nextstrain/. For more infomation about these tracks, see the <a href='http://genome.ucsc.edu/cgi-bin/hgTrackUi?hgsid=840033753_siwhRKP6atS4zAGHBh5gXRmKiyIz&c=NC_045512v2&g=nextstrainSamples'>UCSC/NextStrain information page</a>"
          },
+         "storeClass" : "JBrowse/Store/SeqFeature/VCFTabix",
          "style" : {
-            "height": 8,
+            "height" : 8,
             "showLabels" : false
          },
-         "storeClass" : "JBrowse/Store/SeqFeature/VCFTabix",
          "type" : "CanvasVariants",
          "unsafeMouseover" : true,
          "unsafePopup" : true,
-         "category" : "UCSC/NextStrain",
          "urlTemplate" : "https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/nextstrain/nextstrainSamplesA3.vcf.gz"
       },
-            {
+      {
+         "category" : "UCSC/NextStrain",
          "glyph" : "wormbase-glyphs/View/FeatureGlyph/Diamond",
          "key" : "A6",
          "label" : "A6",
          "metadata" : {
             "about" : "Data derived from NextStrain and displayed on the UCSC Genome Browser. Data for these tracks are coming directly from UCSC servers at https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/nextstrain/. For more infomation about these tracks, see the <a href='http://genome.ucsc.edu/cgi-bin/hgTrackUi?hgsid=840033753_siwhRKP6atS4zAGHBh5gXRmKiyIz&c=NC_045512v2&g=nextstrainSamples'>UCSC/NextStrain information page</a>"
          },
+         "storeClass" : "JBrowse/Store/SeqFeature/VCFTabix",
          "style" : {
-            "height": 8,
+            "height" : 8,
             "showLabels" : false
          },
-         "storeClass" : "JBrowse/Store/SeqFeature/VCFTabix",
          "type" : "CanvasVariants",
          "unsafeMouseover" : true,
          "unsafePopup" : true,
-         "category" : "UCSC/NextStrain",
          "urlTemplate" : "https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/nextstrain/nextstrainSamplesA6.vcf.gz"
       },
-     {
+      {
+         "category" : "UCSC/NextStrain",
          "glyph" : "wormbase-glyphs/View/FeatureGlyph/Diamond",
          "key" : "A7",
          "label" : "A7",
          "metadata" : {
             "about" : "Data derived from NextStrain and displayed on the UCSC Genome Browser. Data for these tracks are coming directly from UCSC servers at https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/nextstrain/. For more infomation about these tracks, see the <a href='http://genome.ucsc.edu/cgi-bin/hgTrackUi?hgsid=840033753_siwhRKP6atS4zAGHBh5gXRmKiyIz&c=NC_045512v2&g=nextstrainSamples'>UCSC/NextStrain information page</a>"
          },
+         "storeClass" : "JBrowse/Store/SeqFeature/VCFTabix",
          "style" : {
-            "height": 8,
+            "height" : 8,
             "showLabels" : false
          },
-         "storeClass" : "JBrowse/Store/SeqFeature/VCFTabix",
          "type" : "CanvasVariants",
          "unsafeMouseover" : true,
          "unsafePopup" : true,
-         "category" : "UCSC/NextStrain",
          "urlTemplate" : "https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/nextstrain/nextstrainSamplesA7.vcf.gz"
       },
       {
+         "category" : "UCSC/NextStrain",
          "glyph" : "wormbase-glyphs/View/FeatureGlyph/Diamond",
          "key" : "B",
          "label" : "B",
          "metadata" : {
             "about" : "Data derived from NextStrain and displayed on the UCSC Genome Browser. Data for these tracks are coming directly from UCSC servers at https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/nextstrain/. For more infomation about these tracks, see the <a href='http://genome.ucsc.edu/cgi-bin/hgTrackUi?hgsid=840033753_siwhRKP6atS4zAGHBh5gXRmKiyIz&c=NC_045512v2&g=nextstrainSamples'>UCSC/NextStrain information page</a>"
          },
+         "storeClass" : "JBrowse/Store/SeqFeature/VCFTabix",
          "style" : {
-            "height": 8,
+            "height" : 8,
             "showLabels" : false
          },
-         "storeClass" : "JBrowse/Store/SeqFeature/VCFTabix",
          "type" : "CanvasVariants",
          "unsafeMouseover" : true,
          "unsafePopup" : true,
-         "category" : "UCSC/NextStrain",
          "urlTemplate" : "https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/nextstrain/nextstrainSamplesB.vcf.gz"
       },
       {
+         "category" : "UCSC/NextStrain",
          "glyph" : "wormbase-glyphs/View/FeatureGlyph/Diamond",
          "key" : "B1",
          "label" : "B1",
          "metadata" : {
             "about" : "Data derived from NextStrain and displayed on the UCSC Genome Browser. Data for these tracks are coming directly from UCSC servers at https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/nextstrain/. For more infomation about these tracks, see the <a href='http://genome.ucsc.edu/cgi-bin/hgTrackUi?hgsid=840033753_siwhRKP6atS4zAGHBh5gXRmKiyIz&c=NC_045512v2&g=nextstrainSamples'>UCSC/NextStrain information page</a>"
          },
+         "storeClass" : "JBrowse/Store/SeqFeature/VCFTabix",
          "style" : {
-            "height": 8,
+            "height" : 8,
             "showLabels" : false
          },
-         "storeClass" : "JBrowse/Store/SeqFeature/VCFTabix",
          "type" : "CanvasVariants",
          "unsafeMouseover" : true,
          "unsafePopup" : true,
-         "category" : "UCSC/NextStrain",
          "urlTemplate" : "https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/nextstrain/nextstrainSamplesB1.vcf.gz"
       },
       {
+         "category" : "UCSC/NextStrain",
          "glyph" : "wormbase-glyphs/View/FeatureGlyph/Diamond",
          "key" : "B2",
          "label" : "B2",
          "metadata" : {
             "about" : "Data derived from NextStrain and displayed on the UCSC Genome Browser. Data for these tracks are coming directly from UCSC servers at https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/nextstrain/. For more infomation about these tracks, see the <a href='http://genome.ucsc.edu/cgi-bin/hgTrackUi?hgsid=840033753_siwhRKP6atS4zAGHBh5gXRmKiyIz&c=NC_045512v2&g=nextstrainSamples'>UCSC/NextStrain information page</a>"
          },
+         "storeClass" : "JBrowse/Store/SeqFeature/VCFTabix",
          "style" : {
-            "height": 8,
+            "height" : 8,
             "showLabels" : false
          },
-         "storeClass" : "JBrowse/Store/SeqFeature/VCFTabix",
          "type" : "CanvasVariants",
          "unsafeMouseover" : true,
          "unsafePopup" : true,
-         "category" : "UCSC/NextStrain",
          "urlTemplate" : "https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/nextstrain/nextstrainSamplesB2.vcf.gz"
       },
       {
+         "category" : "UCSC/NextStrain",
          "glyph" : "wormbase-glyphs/View/FeatureGlyph/Diamond",
          "key" : "B4",
          "label" : "B4",
          "metadata" : {
             "about" : "Data derived from NextStrain and displayed on the UCSC Genome Browser. Data for these tracks are coming directly from UCSC servers at https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/nextstrain/. For more infomation about these tracks, see the <a href='http://genome.ucsc.edu/cgi-bin/hgTrackUi?hgsid=840033753_siwhRKP6atS4zAGHBh5gXRmKiyIz&c=NC_045512v2&g=nextstrainSamples'>UCSC/NextStrain information page</a>"
          },
+         "storeClass" : "JBrowse/Store/SeqFeature/VCFTabix",
          "style" : {
-            "height": 8,
+            "height" : 8,
             "showLabels" : false
          },
-         "storeClass" : "JBrowse/Store/SeqFeature/VCFTabix",
          "type" : "CanvasVariants",
          "unsafeMouseover" : true,
          "unsafePopup" : true,
-         "category" : "UCSC/NextStrain",
          "urlTemplate" : "https://hgdownload.soe.ucsc.edu/gbdb/wuhCor1/nextstrain/nextstrainSamplesB4.vcf.gz"
       },
       {
@@ -482,11 +484,11 @@
          "metadata" : {
             "about" : "Reference sequence and gene features are from RefSeq: https://www.ncbi.nlm.nih.gov/nuccore/NC_045512."
          },
-	 "onClick" : {
-           "iconClass" : "dijitIconDatabase",
-           "action" : "newWindow",
-           "url" : "function(track,f) {var dbxref = f.get('dbxref'); dbxref = dbxref.substring(7);  return 'https://www.ncbi.nlm.nih.gov/gene/' + dbxref; }",
-           "label" : "Go to the gene page for {name} at GenBank"
+         "onClick" : {
+            "action" : "newWindow",
+            "iconClass" : "dijitIconDatabase",
+            "label" : "Go to the gene page for {name} at GenBank",
+            "url" : "function(track,f) {var dbxref = f.get('dbxref'); dbxref = dbxref.substring(7);  return 'https://www.ncbi.nlm.nih.gov/gene/' + dbxref; }"
          },
          "storeClass" : "JBrowse/Store/SeqFeature/NCList",
          "style" : {
@@ -505,11 +507,11 @@
          "metadata" : {
             "about" : "Reference sequence and gene features are from RefSeq: https://www.ncbi.nlm.nih.gov/nuccore/NC_045512.  The color scheme for CDS features attempts to mimic the colors used at NextStrain: https://nextstrain.org/ncov?gmin=27585"
          },
-	 "onClick" : {
-           "iconClass" : "dijitIconDatabase",
-           "action" : "newWindow",
-           "url" : "https://www.ncbi.nlm.nih.gov/protein/{name}",
-           "label" : "Go to the protein page for {name} at GenBank"
+         "onClick" : {
+            "action" : "newWindow",
+            "iconClass" : "dijitIconDatabase",
+            "label" : "Go to the protein page for {name} at GenBank",
+            "url" : "https://www.ncbi.nlm.nih.gov/protein/{name}"
          },
          "storeClass" : "JBrowse/Store/SeqFeature/NCList",
          "style" : {
@@ -539,9 +541,9 @@
          "compress" : 1,
          "key" : "PCR Primers suggested by Jung et. al.",
          "label" : "PCR Primers suggested by Jung et. al.",
-	 "metadata" : {
+         "metadata" : {
             "about" : "Primers and probes suggested by Jung et. al.  See https://www.biorxiv.org/content/10.1101/2020.02.25.964775v1.full.pdf for more information."
-	 },
+         },
          "storeClass" : "JBrowse/Store/SeqFeature/NCList",
          "style" : {
             "className" : "feature"
@@ -554,14 +556,8 @@
          "compress" : 1,
          "key" : "Mature peptides (RefSeq)",
          "label" : "Mature peptides (RefSeq)",
-         "storeClass" : "JBrowse/Store/SeqFeature/NCList",
          "metadata" : {
             "about" : "Mature peptide regions for orf1ab came directly from a GFF download from NCBI at https://www.ncbi.nlm.nih.gov/nuccore/NC_045512. The remainder of the features in this track were inferred from the feature descriptions at the same page for NC_045512.  The resulting GFF was processed with the flatfile_to_json."
-         },
-         "style" : {
-            "className" : "feature",
-            "height" : 5,
-            "color" : "cyan"
          },
          "onClick" : {
             "action" : "newWindow",
@@ -569,9 +565,45 @@
             "label" : "Go to the protein page for {name} at GenBank",
             "url" : "function(track,f) {var name = f.get('Name');  return 'https://www.ncbi.nlm.nih.gov/protein/' + name; }"
          },
+         "storeClass" : "JBrowse/Store/SeqFeature/NCList",
+         "style" : {
+            "className" : "feature",
+            "color" : "cyan",
+            "height" : 5
+         },
          "trackType" : "CanvasFeatures",
          "type" : "CanvasFeatures",
          "urlTemplate" : "https://s3.amazonaws.com/gmod-genomes-of-interest/jbrowse/data/SARS-CoV-2/tracks/Mature peptides (RefSeq)/{refseq}/trackData.jsonz"
+      },
+      {
+         "compress" : 1,
+         "key" : "Mature peptides",
+         "label" : "All Genes",
+         "storeClass" : "JBrowse/Store/SeqFeature/NCList",
+         "style" : {
+            "className" : "feature"
+         },
+	 "style" : {
+            "className" : "feature",
+            "color" : "cyan",
+	    "borderWidth" : 2,
+	    "borderColor" : "black",
+            "height" : 7
+         },
+	 "onClick" : {
+            "action" : "newWindow",
+            "iconClass" : "dijitIconDatabase",
+            "label" : "Go to the protein page for {name} at GenBank",
+            "url" : "function(track,f) {var name = f.get('Name');  return 'https://www.ncbi.nlm.nih.gov/protein/' + name; }"
+         },
+	 "metadata" : {
+            "about" : "Data in this track are primarily derived from RefSeq GFF for NC_045512.2, with some additions noted in the header for the GFF file, at https://github.com/GMOD/sars-cov-2-jbrowse/blob/master/jbrowse/data/SARS-CoV-2/NC_045512.2.gff3."
+	 },
+         "trackType" : "CanvasFeatures",
+         "type" : "CanvasFeatures",
+	 "subParts" : "mature_protein_region",
+	 "glyph" : "JBrowse/View/FeatureGlyph/Segments",
+         "urlTemplate" : "https://s3.amazonaws.com/gmod-genomes-of-interest/jbrowse/data/SARS-CoV-2/tracks/All Genes/{refseq}/trackData.jsonz"
       }
    ]
 }


### PR DESCRIPTION
Gives the protein features parents. There are two reasons to do this:
1. to allow the pieces of the ribosome slipped protein to be grouped together
2. to allow the GenomeFeatureComponent to work with these data.